### PR TITLE
Add configurable password

### DIFF
--- a/Redis.py
+++ b/Redis.py
@@ -5,9 +5,6 @@ import re
 import commands
 
 
-REDIS_INFO_CMD = "redis-cli info"
-
-
 class Redis:
     def __init__(self, agent_config, checks_logger, raw_config):
         self.agent_config = agent_config
@@ -16,7 +13,7 @@ class Redis:
 
     def run(self):
         stats = {}
-        status, out = commands.getstatusoutput(REDIS_INFO_CMD)
+        status, out = commands.getstatusoutput(self.redis_info_cmd())
         if status != 0:
             return stats
         # Grab every statistic available and leave it to the end user to
@@ -24,6 +21,13 @@ class Redis:
         for key, val in [line.split(':') for line in out.splitlines()]:
             stats[key] = val
         return stats
+
+    def redis_info_cmd(self):
+        if self.raw_config.get('Redis') and self.raw_config['Redis'].get('password'):
+                self.checks_logger.debug('Found Redis password in config')
+                return "redis_cli -a %s info" % self.raw_config['Redis']['password']
+        else:
+                return "redis_cli info"
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This patch will call `redis_cli` using a password if one is present in the `/etc/sd-agent/config.cfg` file.

For example, this config section:

```
[Redis]
password: sekret
```

would cause the redis info command to be

```
redis_cli -a sekret info
```

If none is present, the simple `redis_cli info` command is used.
